### PR TITLE
Implement drag and drop based order in sidebar for local space

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mdi/js": "^5.9.55",
         "@mdi/react": "^1.2.1",
         "@types/react-color": "^3.0.4",
+        "array-move": "^2.2.1",
         "chart.js": "^2.9.4",
         "classcat": "^4.0.2",
         "codemirror": "^5.59.2",
@@ -19198,6 +19199,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-move": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-2.2.2.tgz",
+      "integrity": "sha512-lKc6C+nsOSA1o7eHSP/HshlGDYUI7QKyaus5kPDm2zEEPQID9xlspnraLR8l+rDlqg9mGo8ziE7F8TEnF6D3Tw==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/array-union": {
@@ -62511,6 +62523,11 @@
         "es-abstract": "^1.17.0",
         "is-string": "^1.0.5"
       }
+    },
+    "array-move": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/array-move/-/array-move-2.2.2.tgz",
+      "integrity": "sha512-lKc6C+nsOSA1o7eHSP/HshlGDYUI7QKyaus5kPDm2zEEPQID9xlspnraLR8l+rDlqg9mGo8ziE7F8TEnF6D3Tw=="
     },
     "array-union": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@mdi/js": "^5.9.55",
     "@mdi/react": "^1.2.1",
     "@types/react-color": "^3.0.4",
+    "array-move": "^2.2.1",
     "chart.js": "^2.9.4",
     "classcat": "^4.0.2",
     "codemirror": "^5.59.2",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -21,6 +21,7 @@ import ContextMenu from '../shared/components/molecules/ContextMenu'
 import AppNavigator from './organisms/AppNavigator'
 import Toast from '../shared/components/organisms/Toast'
 import styled from '../shared/lib/styled'
+import { useToast } from '../shared/lib/stores/toast'
 
 const LoadingText = styled.div`
   margin: 30px;
@@ -36,11 +37,12 @@ const AppContainer = styled.div`
 `
 
 const App = () => {
-  const { initialize, storageMap } = useDb()
+  const { initialize, storageMap, getUninitializedStorageData } = useDb()
   const { push, pathname } = useRouter()
   const [initialized, setInitialized] = useState(false)
   const { togglePreferencesModal, preferences } = usePreferences()
   const { navigate: navigateToStorage } = useStorageRouter()
+  const { pushMessage } = useToast()
 
   useEffectOnce(() => {
     initialize()
@@ -60,8 +62,21 @@ const App = () => {
           }
         }
         setInitialized(true)
+
+        // notify on failed initializations
+        const uninitializedStorageData = await getUninitializedStorageData()
+        if (uninitializedStorageData.length > 0) {
+          pushMessage({
+            title: 'Error',
+            description: `Failed to initialize some storages, please check console for more info.`,
+          })
+        }
       })
       .catch((error) => {
+        pushMessage({
+          title: 'Error',
+          description: `Failed to initialize some storages, please check console for more info.`,
+        })
         console.error(error)
       })
   })

--- a/src/components/organisms/FolderDetail.tsx
+++ b/src/components/organisms/FolderDetail.tsx
@@ -18,6 +18,7 @@ import {
   selectStyle,
 } from '../../shared/lib/styled/styleFunctions'
 import styled from '../../shared/lib/styled'
+import { NOTE_ID_PREFIX } from '../../lib/db/consts'
 
 interface FolderDetailProps {
   storage: NoteStorage
@@ -46,7 +47,11 @@ const FolderDetail = ({ storage, folderPathname }: FolderDetailProps) => {
       return []
     }
 
-    return [...folder.noteIdSet]
+    return [
+      ...(folder.orderedIds || []).filter((orderId) =>
+        orderId.startsWith(NOTE_ID_PREFIX)
+      ),
+    ]
       .reduce((notes, noteId) => {
         const note = storage.noteMap[noteId]
         if (note != null && !note.trashed) {

--- a/src/components/organisms/SidebarContainer.tsx
+++ b/src/components/organisms/SidebarContainer.tsx
@@ -22,12 +22,10 @@ import { useTranslation } from 'react-i18next'
 import { useSearchModal } from '../../lib/searchModal'
 import styled from '../../shared/lib/styled'
 import cc from 'classcat'
+import { SidebarTreeSortingOrders } from '../../shared/lib/sidebar'
 import { useGeneralStatus } from '../../lib/generalStatus'
 import { useLocalUI } from '../../lib/v2/hooks/local/useLocalUI'
-import {
-  mapTree,
-  SidebarTreeSortingOrders,
-} from '../../lib/v2/mappers/local/sidebarTree'
+import { mapTree } from '../../lib/v2/mappers/local/sidebarTree'
 import { useLocalDB } from '../../lib/v2/hooks/local/useLocalDB'
 import { useLocalDnd } from '../../lib/v2/hooks/local/useLocalDnd'
 import { CollapsableType } from '../../lib/v2/stores/sidebarCollapse'
@@ -275,14 +273,22 @@ const SidebarContainer = ({
   )
 
   const getFoldEvents = useCallback(
-    (type: CollapsableType, key: string) => {
+    (type: CollapsableType, key: string, reversed?: boolean) => {
+      if (reversed) {
+        return {
+          fold: () => unfoldItem(type, key),
+          unfold: () => foldItem(type, key),
+          toggle: () => toggleItem(type, key),
+        }
+      }
+
       return {
         fold: () => foldItem(type, key),
         unfold: () => unfoldItem(type, key),
         toggle: () => toggleItem(type, key),
       }
     },
-    [foldItem, unfoldItem, toggleItem]
+    [toggleItem, unfoldItem, foldItem]
   )
 
   const tree = useMemo(() => {
@@ -338,11 +344,13 @@ const SidebarContainer = ({
   const sidebarHeaderControls: SidebarControls = useMemo(() => {
     return {
       'View Options': (tree || []).map((category) => {
+        const key = (category.label || '').toLocaleLowerCase()
+        const hideKey = `hide-${key}`
         return {
           type: 'check',
           label: category.label,
-          checked: !sideBarOpenedLinksIdsSet.has(`hide-${category.label}`),
-          onClick: () => toggleItem('links', `hide-${category.label}`),
+          checked: !sideBarOpenedLinksIdsSet.has(hideKey),
+          onClick: () => toggleItem('links', hideKey),
         }
       }),
       Sorting: Object.values(SidebarTreeSortingOrders).map((sort) => {

--- a/src/lib/db/FSNoteDb.ts
+++ b/src/lib/db/FSNoteDb.ts
@@ -92,8 +92,8 @@ class FSNoteDb implements NoteDb {
     const allFolders = await this.getAllFolders()
     let anyFolderDocUpdated = false
     allFolders.forEach((folderDoc) => {
-      if (folderDoc._realId === undefined) {
-        folderDoc._realId = generateFolderId()
+      if (folderDoc.orderId === undefined) {
+        folderDoc.orderId = generateFolderId()
         anyFolderDocUpdated = true
       }
     })
@@ -122,7 +122,7 @@ class FSNoteDb implements NoteDb {
   async upsertFolder(
     pathname: string,
     props?: Partial<FolderDocEditibleProps>,
-    oldRealId?: string,
+    oldOrderId?: string,
     skipParentFolderCreation?: boolean
   ): Promise<FolderDoc> {
     if (!isFolderPathnameValid(pathname)) {
@@ -139,15 +139,15 @@ class FSNoteDb implements NoteDb {
       return folder
     }
     const now = getNow()
-    const newRealId =
-      folder != null && folder._realId != null ? folder._realId : oldRealId
+    const newOrderId =
+      folder != null && folder.orderId != null ? folder.orderId : oldOrderId
     const newFolderDoc = {
       ...(folder || {
         _id: getFolderId(pathname),
         createdAt: now, // todo: [komediruzecki-10/07/2021] FIXME: should be updated at when renaming folder!
         data: {},
       }),
-      _realId: newRealId != null ? newRealId : generateFolderId(),
+      orderId: newOrderId != null ? newOrderId : generateFolderId(),
       ...props,
       orderedIds: removeDuplicates([
         ...(props != null ? props.orderedIds || [] : []),
@@ -185,7 +185,7 @@ class FSNoteDb implements NoteDb {
     const folderToDelete = await this.getFolder(pathname)
     if (parentFolder != null && folderToDelete != null) {
       const newParentOrderedIds = (parentFolder.orderedIds || []).filter(
-        (orderId) => orderId != folderToDelete._realId
+        (orderId) => orderId != folderToDelete.orderId
       )
       newFolderMap[getParentFolderPathname(pathname)] = {
         ...parentFolder,
@@ -597,14 +597,14 @@ class FSNoteDb implements NoteDb {
     for (const folderPathname of allFoldersToRename) {
       const newFolderPathname = replacePathname(folderPathname)
       const oldFolderDoc = await this.getFolder(folderPathname)
-      const oldRealId = oldFolderDoc != null ? oldFolderDoc._realId : undefined
+      const oldOrderId = oldFolderDoc != null ? oldFolderDoc.orderId : undefined
       const newFolder = await this.upsertFolder(
         newFolderPathname,
         {
           orderedIds:
             oldFolderDoc != null ? oldFolderDoc.orderedIds : undefined,
         },
-        oldRealId,
+        oldOrderId,
         true
       )
       updatedFolderMap.set(newFolderPathname, {
@@ -625,7 +625,7 @@ class FSNoteDb implements NoteDb {
       if (previousParentFolder != null && newParentFolder != null) {
         const newPreviousParentOrderedIds = removeDuplicates(
           (previousParentFolder.orderedIds || []).filter(
-            (orderId) => folder._realId != orderId
+            (orderId) => folder.orderId != orderId
           )
         )
 
@@ -634,7 +634,7 @@ class FSNoteDb implements NoteDb {
         // new parent folder update
         const newParentOrderedIds = removeDuplicates([
           ...(newParentFolder.orderedIds || []),
-          folder._realId,
+          folder.orderId,
         ])
         const newParentFolderPathname = getParentFolderPathname(newPathname)
 
@@ -694,7 +694,7 @@ class FSNoteDb implements NoteDb {
     )
     updatedFolderMap.forEach((updatedFolderDoc) => {
       const {
-        _realId,
+        orderId,
         _id,
         createdAt,
         updatedAt,
@@ -702,7 +702,7 @@ class FSNoteDb implements NoteDb {
         orderedIds,
       } = updatedFolderDoc
       newFolderMap[updatedFolderDoc.pathname] = {
-        _realId,
+        orderId: orderId,
         _id,
         createdAt,
         updatedAt,

--- a/src/lib/db/createStore.ts
+++ b/src/lib/db/createStore.ts
@@ -345,7 +345,7 @@ export function createDbStoreCreator(
           const previousOrderedIds = parentFolder.orderedIds || []
           const newOrderedIds = removeDuplicates([
             ...previousOrderedIds,
-            aFolder._realId,
+            aFolder.orderId,
           ])
           const updatedFolder = await storage.db.upsertFolder(
             parentFolder.pathname,
@@ -905,7 +905,7 @@ export function createDbStoreCreator(
           const previousOrderedIds = parentFolder.orderedIds || []
           const newOrderedIds = removeDuplicates([
             ...previousOrderedIds,
-            folder._realId,
+            folder.orderId,
           ])
 
           const updatedParentFolder = await storage.db.updateFolderOrderedIds(
@@ -1407,7 +1407,7 @@ async function prepareStorage(
         const subFolderDoc = populatedFolderMap[subFolderPathname]
         if (subFolderDoc != null) {
           populatedFolderMap[parentFolderPathname]!.orderedIds!.push(
-            subFolderDoc._realId
+            subFolderDoc.orderId
           )
         }
       })

--- a/src/lib/db/patterns.ts
+++ b/src/lib/db/patterns.ts
@@ -1,5 +1,28 @@
 import { NavResource } from '../v2/interfaces/resources'
+import { getFolderPathname, getParentFolderPathname } from './utils'
+import { DraggedTo, SidebarDragState } from '../../shared/lib/dnd'
 
 export function getResourceId(source: NavResource) {
-  return source.result._id
+  if (source.type == 'folder') {
+    return source.result._realId
+  } else {
+    return source.result._id
+  }
+}
+
+export function getResourceParentPathname(
+  source: NavResource,
+  targetedPosition?: SidebarDragState
+) {
+  if (source.type == 'doc') {
+    return source.result.folderPathname
+  } else {
+    if (targetedPosition == DraggedTo.insideFolder) {
+      return getFolderPathname(source.result._id)
+    } else if (targetedPosition == DraggedTo.beforeItem) {
+      return getParentFolderPathname(getFolderPathname(source.result._id))
+    } else {
+      return getParentFolderPathname(getFolderPathname(source.result._id))
+    }
+  }
 }

--- a/src/lib/db/patterns.ts
+++ b/src/lib/db/patterns.ts
@@ -4,7 +4,7 @@ import { DraggedTo, SidebarDragState } from '../../shared/lib/dnd'
 
 export function getResourceId(source: NavResource) {
   if (source.type == 'folder') {
-    return source.result._realId
+    return source.result.orderId
   } else {
     return source.result._id
   }

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -37,12 +37,14 @@ export type NoteDoc = {
 
 export type FolderDoc = {
   _id: string // folder:${FOLDER_PATHNAME}
+  _realId: string // identification for reordering (unique across any property change)
   createdAt: string
   updatedAt: string
   _rev?: string
 } & FolderDocEditibleProps
 
 export type FolderDocEditibleProps = {
+  orderedIds?: string[]
   data: JsonObject
 }
 
@@ -88,7 +90,6 @@ export type FSNoteStorage = FSNoteStorageData &
 export type NoteStorage = FSNoteStorage
 export type PopulatedFolderDoc = FolderDoc & {
   pathname: string
-  noteIdSet: NoteIdSet
 }
 
 export type PopulatedTagDoc = TagDoc & {
@@ -102,4 +103,10 @@ export interface AllPopulatedDocsMap {
   tagMap: ObjectMap<PopulatedTagDoc>
   attachmentMap: ObjectMap<Attachment>
   bookmarkedItemIds: string[]
+}
+
+export interface LiteStorageStorageItem {
+  id?: string
+  name?: string
+  location?: string
 }

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -37,7 +37,7 @@ export type NoteDoc = {
 
 export type FolderDoc = {
   _id: string // folder:${FOLDER_PATHNAME}
-  _realId: string // identification for reordering (unique across any property change)
+  orderId: string // identification for reordering (unique across any property change)
   createdAt: string
   updatedAt: string
   _rev?: string

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -6,6 +6,8 @@ import {
   FolderDoc,
   NoteStorage,
   PopulatedTagDoc,
+  NoteStorageData,
+  LiteStorageStorageItem,
 } from './types'
 import { generateId, escapeRegExp } from '../string'
 
@@ -29,12 +31,23 @@ export function generateNoteId(): string {
   return `${NOTE_ID_PREFIX}${generateId()}`
 }
 
+export function generateFolderId(): string {
+  return `${FOLDER_ID_PREFIX}${generateId()}`
+}
+
 export function excludeNoteIdPrefix(noteId: string): string {
   return noteId.replace(new RegExp(`^${NOTE_ID_PREFIX}`), '')
 }
 
 export function excludeFileProtocol(src: string) {
   return src.replace('file://', '')
+}
+
+export function prependFolderIdPrefix(folderPathname: string): string {
+  if (new RegExp(`^${FOLDER_ID_PREFIX}`).test(folderPathname)) {
+    return folderPathname
+  }
+  return `${FOLDER_ID_PREFIX}${folderPathname}`
 }
 
 export function getWorkspaceHref(storage: NoteStorage, query?: any): string {
@@ -215,4 +228,15 @@ export function getAllParentFolderPathnames(pathname: string) {
 
 export function normalizeTagColor(tag: PopulatedTagDoc): string {
   return typeof tag.data.color == 'string' ? tag.data.color : ''
+}
+
+export function mapStorageToLiteStorageData(
+  storage: NoteStorage | NoteStorageData
+): LiteStorageStorageItem {
+  const { id, name } = storage
+  return {
+    id,
+    name,
+    location: storage.location,
+  }
 }

--- a/src/lib/localStorageKeys.ts
+++ b/src/lib/localStorageKeys.ts
@@ -1,5 +1,5 @@
 export const preferencesKey = 'note.boostio.co:preferences'
-export const storageDataListKey = 'note.boostio.co:storageDataList'
+export const storageDataListKey = 'note.boostio.co:localStorageDataList'
 export const generalStatusKey = 'note.boostio.co:generalStatusKey'
 export const previewStyleKey = 'note.boostio.co:previewStyleKey'
 export const defaultStorageCreatedKey =

--- a/src/lib/v2/hooks/local/useLocalDB.ts
+++ b/src/lib/v2/hooks/local/useLocalDB.ts
@@ -26,6 +26,7 @@ export function useLocalDB() {
     unbookmarkNote,
     updateNote,
     renameFolder,
+    updateFolderOrderedIds,
     storageMap: workspaceMap,
   } = useDb()
   const { push } = useRouter()
@@ -145,7 +146,7 @@ export function useLocalDB() {
       await send(workspace.id, 'delete', {
         api: () => removeStorage(workspace.id),
         cb: () => {
-          // maybe push message to notify successfully update
+          // maybe push message to notify successful update
         },
       })
     },
@@ -157,7 +158,7 @@ export function useLocalDB() {
       await send(target.workspaceId, 'delete', {
         api: () => removeFolder(target.workspaceId, target.pathname),
         cb: () => {
-          // maybe push message to notify successfully update
+          // maybe push message to notify successful update
         },
       })
     },
@@ -169,25 +170,37 @@ export function useLocalDB() {
       return send(target.workspaceId, 'delete', {
         api: () => deleteNote(target.workspaceId, target.docId),
         cb: () => {
-          // maybe push message to notify successfully update
+          // maybe push message to notify successful update
         },
       })
     },
     [send, deleteNote]
   )
 
-  const updateFolderApi = useCallback(
+  const renameFolderApi = useCallback(
     async (target: FolderDoc, body: UpdateFolderRequestBody) => {
       await send(target._id, 'update', {
         api: () =>
-          // generic update not available, rename instead
           renameFolder(body.workspaceId, body.oldPathname, body.newPathname),
         cb: () => {
-          // maybe push message to notify successfully update
+          // maybe push message to notify successful update
         },
       })
     },
     [send, renameFolder]
+  )
+
+  const updateFolderOrderedIdsApi = useCallback(
+    async (resourceId, body: UpdateFolderOrderedIdsRequestBody) => {
+      await send(resourceId, 'update', {
+        api: () =>
+          updateFolderOrderedIds(body.workspaceId, resourceId, body.orderedIds),
+        cb: () => {
+          // maybe push message to notify successful update
+        },
+      })
+    },
+    [send, updateFolderOrderedIds]
   )
 
   const updateDocApi = useCallback(
@@ -195,10 +208,7 @@ export function useLocalDB() {
       await send(docId, 'update', {
         api: () => updateNote(body.workspaceId, docId, body.docProps),
         cb: () => {
-          // if (pageDoc != null && doc.id === pageDoc.id) {
-          //   setPartialPageData({ pageDoc: doc })
-          //   setCurrentPath(doc.folderPathname)
-          // }
+          // maybe push message to notify successful update
         },
       })
     },
@@ -217,7 +227,8 @@ export function useLocalDB() {
     deleteFolderApi,
     deleteDocApi,
     updateDocApi,
-    updateFolder: updateFolderApi,
+    renameFolderApi,
+    updateFolderOrderedIdsApi,
     workspaceMap,
   }
 }
@@ -242,6 +253,11 @@ export interface UpdateFolderRequestBody {
   workspaceId: string
   oldPathname: string
   newPathname: string
+}
+
+export interface UpdateFolderOrderedIdsRequestBody {
+  workspaceId: string
+  orderedIds: string[]
 }
 
 export interface UpdateDocRequestBody {

--- a/src/lib/v2/mappers/local/sidebarTree.tsx
+++ b/src/lib/v2/mappers/local/sidebarTree.tsx
@@ -130,7 +130,7 @@ function getFolderChildrenOrderedIds(
   folders.forEach((folder) => {
     const folderPathname = getFolderPathname(folder._id)
     if (isDirectSubPathname(parentFolderPathname, folderPathname)) {
-      children.push(folder._realId)
+      children.push(folder.orderId)
     }
   })
 
@@ -218,7 +218,7 @@ export function mapTree(
   const items = new Map<string, LocalTreeItem>()
   const [notes, folders] = [values(docMap), values(folderMap)]
   folders.forEach((folder) => {
-    const folderRealId = folder._realId
+    const folderOrderId = folder.orderId
     const folderId = folder._id
     const folderPathname = getFolderPathname(folderId)
     if (folderPathname == '/') {
@@ -230,14 +230,14 @@ export function mapTree(
     const parentFolderDoc = folderMap[parentFolderPathname]
     const parentFolderId =
       parentFolderDoc != null && parentFolderPathname != '/'
-        ? parentFolderDoc._realId
+        ? parentFolderDoc.orderId
         : workspace.id
-    items.set(folderRealId, {
-      id: folderRealId,
+    items.set(folderOrderId, {
+      id: folderOrderId,
       lastUpdated: folder.updatedAt,
       label: folderName,
-      folded: !sideBarOpenedFolderIdsSet.has(folderRealId),
-      folding: getFoldEvents('folders', folderRealId),
+      folded: !sideBarOpenedFolderIdsSet.has(folderOrderId),
+      folding: getFoldEvents('folders', folderOrderId),
       href,
       active: href === currentPathWithWorkspace,
       navigateTo: () => push(href),
@@ -341,7 +341,7 @@ export function mapTree(
       parentFolderDoc != null
         ? parentFolderDoc.pathname == '/'
           ? workspace.id
-          : parentFolderDoc._realId
+          : parentFolderDoc.orderId
         : workspace.id
     items.set(noteId, {
       id: noteId,

--- a/src/lib/v2/stores/sidebarCollapse/store.tsx
+++ b/src/lib/v2/stores/sidebarCollapse/store.tsx
@@ -13,7 +13,7 @@ import { useActiveStorageId } from '../../../routeParams'
 const initialContent: CollapsableContent = {
   folders: [],
   workspaces: [],
-  links: [`hide-labels`, 'hide-status'],
+  links: [],
 }
 
 function useSidebarCollapseStore(): SidebarCollapseContext {


### PR DESCRIPTION
This PR also introduces few key changes and bugfixes:
1. Storage loading is handled differently (all storages loaded nevertheless of errors, error ones stored for futher loading, any error is logged properly)
2. Fixes a bug with regex being global and thus in particular situations creates wrong list of subfolders of a parent (not all)
3. Fixes a bug with hide sidebar items, wrong keys used in SidebarContainer
4. Implements drag and drop (with ordered IDs, real Folder IDs, few createStore and FSNote DB refactors, few minor bugfixes)

Add array move lib
Implemented orderedIds and DnD handling
Add logic for moving note or doc into note target
Add basic Database updates and API for orderedIds changes
Implement ordered IDs initialization in storages
Implement ordered IDs initializatio only in FSNote
Remove excess function from createStore

Updated handling of pouch DB in createStore
Add create note update for parent folder ordered IDs

Fix direct subfolders rather than all for create subfolders function
Add implementation of trash/untrash note workspace orderedIds

Update rename folder to update ordered IDs as well
Implement createNote update of ordered IDs (workspace)
Implement createFolder update of ordered IDs (workspace and parent folders)
Implement folder reordering
Implement moving of folders across different folder
Refactor folder IDs to use real IDs
Initialize real IDs (only FSNoteDB)
Update rename folder so that it handles realIDs updates (previous and new parent folders ordered IDs update)
Refactor code to use root folder instead of workspace ordered Ids
Refactor and update for loading of storages
Some improvements on loading multiple storages and some fails
Add folder realID changing instead of reusing (also previous ordered IDs should be persisted on folder rename)
Add handling of trash/untrash regarding ordered Ids

Some ordered IDs bugfixes

Remove console logs (most of them)
Fix bug with parallel execution and parent folder creation on rename folder upsert folder calls

Remove note id set from local space

Fix bug with hiding items in sidebar (invalid key provided on callback)
Assess some todos

Update storages list data key

Add order ID removal in purge note
Fix sidebar tree ordered IDs handling

Rename realId to orderId 