### PR TITLE
Fix menu items and missing storage tab in preferences

### DIFF
--- a/src/components/PreferencesModal/AboutTab.tsx
+++ b/src/components/PreferencesModal/AboutTab.tsx
@@ -140,7 +140,7 @@ const AboutTab = () => {
             <div className='about-community-links'>
               <ul>
                 <li>
-                  <PrimaryLink href='https://github.com/BoostIO/BoostNote.next'>
+                  <PrimaryLink href='https://github.com/BoostIO/BoostNote.next-local'>
                     {t('about.github')}
                   </PrimaryLink>
                 </li>

--- a/src/components/PreferencesModal/PreferencesModal.tsx
+++ b/src/components/PreferencesModal/PreferencesModal.tsx
@@ -180,6 +180,13 @@ const PreferencesModal = () => {
               active={tab === 'about'}
               onClick={() => openTab('about')}
             />
+            {currentStorage !== null && (
+              <SettingNavButtonItem
+                label='Space'
+                active={tab === 'storage'}
+                onClick={() => openTab('storage')}
+              />
+            )}
             <SettingNavButtonItem
               label={t('preferences.keymap')}
               active={tab === 'keymap'}

--- a/src/components/PreferencesModal/StorageTab.tsx
+++ b/src/components/PreferencesModal/StorageTab.tsx
@@ -67,7 +67,7 @@ const StorageEditPage = ({ storage }: StorageEditPageProps) => {
   return (
     <div>
       <h2>Space Settings</h2>
-      <p>Location : {storage.location}</p>
+      <p>Location: {storage.location}</p>
 
       <FormLabelGroup>
         <FormLabelGroupLabel>Space Name</FormLabelGroupLabel>

--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -282,10 +282,10 @@ export function getTemplateFromKeymap(
         { role: 'forcereload' },
         { role: 'toggledevtools' },
         { type: 'separator' },
-        // { role: 'resetzoom' },
-        // { role: 'zoomin' },
-        // { role: 'zoomout' },
-        // { type: 'separator' },
+        { role: 'resetzoom' },
+        { role: 'zoomin' },
+        { role: 'zoomout' },
+        { type: 'separator' },
         { role: 'togglefullscreen' },
       ] as MenuItemConstructorOptions[],
     },
@@ -293,7 +293,6 @@ export function getTemplateFromKeymap(
       label: 'Window',
       submenu: [
         { role: 'minimize' },
-        { role: 'zoom' },
         ...(mac
           ? [
               { type: 'separator' },

--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -40,10 +40,6 @@ export function getTemplateFromKeymap(
               },
               { type: 'separator' },
               {
-                label: 'Add Cloud Space',
-                click: createEmitIpcMenuItemHandler('create-cloud-space'),
-              },
-              {
                 label: 'Add Local Space',
                 click: createEmitIpcMenuItemHandler('create-local-space'),
               },
@@ -111,10 +107,6 @@ export function getTemplateFromKeymap(
               accelerator: keymap.get('editorSaveAs'),
             },
             { type: 'separator' },
-            {
-              label: 'Add Cloud Space',
-              click: createEmitIpcMenuItemHandler('create-cloud-space'),
-            },
             {
               label: 'Add Local Space',
               click: createEmitIpcMenuItemHandler('create-local-space'),
@@ -319,7 +311,7 @@ export function getTemplateFromKeymap(
           label: 'GitHub',
           click: async () => {
             await shell.openExternal(
-              'https://github.com/BoostIO/Boostnote.next'
+              'https://github.com/BoostIO/BoostNote.next-local'
             )
           },
         },
@@ -367,7 +359,7 @@ export function getTemplateFromKeymap(
         {
           label: 'Learn More',
           click: async () => {
-            await shell.openExternal('https://boosthub.io')
+            await shell.openExternal('https://boostnote.io/')
           },
         },
       ] as MenuItemConstructorOptions[],


### PR DESCRIPTION
Fix learn more URL for boostnote (was boosthub now boostnote)
Fix Github repository links (was old repo, now local desktop app repo)
Remove Add cloud space (as local only desktop app here)
Add storage/space tab again (space location needed as well as rename and removal from preferences)