### PR TITLE
Improve space creation and other improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -8,21 +9,33 @@ For more info on features and upcoming changes, please visit our [Open Issues](h
 
 ## [Unreleased]
 
-## [0.21.2] - 2021-08-30
+## [0.21.2] - 2021-09-10
+
 ### Added
+
 - Changelog to repository
 - Proper instructions to `readme.md`
-- Project Wiki documentation (docs/*.md)
+- Project Wiki documentation (docs/\*.md)
+- Updates icon on dialog
+- Codemirror themes `ayu-dark` and `ayu-mirage`
 
 ### Fixed
+
 - Menu items for zoom (zoom in/out/reset)
 - Tag autocomplete not showing the first item
 - Missing Space/Storage info page in Preferences
+- Space creation page sidebar showing when no spaces
+- Sidebar showing when no spaces on 404 pages
+- Navigating to invalid spaces (push message instead of 404 page)
+- Updater message title and descriptions
+- PDF export themes not being consistent with HTML (also add missing CodeMirror default theme)
 
 ### Changed
-- Tag autoclose behavior (no autoclose on adding new tag)
+
+- Tag auto-close behavior (no auto-close on adding new tag)
 
 ### Removed
+
 - Cloud specific menu items
 
 ## [Released]
@@ -30,17 +43,18 @@ For more info on features and upcoming changes, please visit our [Open Issues](h
 ## [0.21.1] - 2021-08-06
 
 ### Removed
-- Cloud feature intro 
+
+- Cloud feature intro
 - Cloud premium feature buttons
 
 ## [0.21.0] - 2021-08-06
 
 ### Removed
+
 - Cloud space support
 
 ### Fixed
+
 - Drag and drop ordering of side navigator
 - Improve app stability (storage loading, error logging, and folder rename regex bug)
 - Update issue of macOS (the app didn't restart properly after updating)
-
-

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -8,7 +8,7 @@ import '../lib/i18n'
 import CodeMirrorStyle from './CodeMirrorStyle'
 import { useEffectOnce } from 'react-use'
 import { useRouter } from '../lib/router'
-import { values, keys } from '../lib/db/utils'
+import { values, keys, size } from '../lib/db/utils'
 import { addIpcListener, removeIpcListener } from '../lib/electronOnly'
 import { useBoostNoteProtocol } from '../lib/protocol'
 import { useStorageRouter } from '../lib/storageRouter'
@@ -103,9 +103,21 @@ const App = () => {
       const storageIds = keys(storageMap)
 
       const targetStorageId = storageIds[index]
-      navigateToStorage(targetStorageId)
+      const spaceCount = size(storageMap)
+      if (index >= spaceCount) {
+        pushMessage({
+          title: 'No such storage.',
+          description: `You selected ${index + 1}${
+            index == 0 ? 'st' : index == 1 ? 'nd' : 'th'
+          } space but only ${spaceCount} space${spaceCount == 1 ? '' : 's'} ${
+            spaceCount > 1 ? 'are' : 'is'
+          } available. Please add more storages or switch to existing ones. `,
+        })
+      } else {
+        navigateToStorage(targetStorageId)
+      }
     },
-    [storageMap, navigateToStorage]
+    [storageMap, navigateToStorage, pushMessage]
   )
 
   useEffect(() => {

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -180,10 +180,12 @@ const Application = ({
       {storage != null && showSearchModal && <SearchModal storage={storage} />}
       <ApplicationLayout
         sidebar={
-          <SidebarContainer
-            workspace={storage}
-            toggleSearchScreen={() => setShowSearchScreen((prev) => !prev)}
-          />
+          storage != null && (
+            <SidebarContainer
+              workspace={storage}
+              toggleSearchScreen={() => setShowSearchScreen((prev) => !prev)}
+            />
+          )
         }
         pageBody={
           showSearchScreen ? (

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -5,7 +5,7 @@ import StorageCreatePage from './pages/StorageCreatePage'
 import { useDb } from '../lib/db'
 import AttachmentsPage from './pages/AttachmentsPage'
 import WikiNotePage from './pages/WikiNotePage'
-import { values } from '../lib/db/utils'
+import { size, values } from '../lib/db/utils'
 import ArchivePage from './pages/ArchivePage'
 import LabelsPage from './pages/LabelsPage'
 import TimelinePage from './pages/TimelinePage'
@@ -67,6 +67,11 @@ const Router = () => {
     case 'workspaces.create':
       return <StorageCreatePage />
   }
+
+  if (size(storageMap) == 0) {
+    return <StorageCreatePage />
+  }
+
   return (
     <NotFoundErrorPage
       title={'Page not found'}

--- a/src/components/organisms/FSStorageCreateForm.tsx
+++ b/src/components/organisms/FSStorageCreateForm.tsx
@@ -47,6 +47,8 @@ const FSStorageCreateForm = () => {
       rows={[
         {
           title: t('storage.name'),
+          description:
+            'Please provide your new storage name or name to use for existing space.',
           items: [
             {
               type: 'input',
@@ -62,6 +64,8 @@ const FSStorageCreateForm = () => {
         },
         {
           title: 'Location',
+          description:
+            'Please select new empty folder for your space or chose existing folder where your boostnote.json file resides.',
           items: [
             {
               type: 'node',

--- a/src/components/organisms/SidebarContainer.tsx
+++ b/src/components/organisms/SidebarContainer.tsx
@@ -8,7 +8,7 @@ import {
   addIpcListener,
   removeIpcListener,
 } from '../../lib/electronOnly'
-import { values } from '../../lib/db/utils'
+import { getTimelineHref, values } from '../../lib/db/utils'
 import { MenuItemConstructorOptions } from 'electron'
 import { useStorageRouter } from '../../lib/storageRouter'
 import {
@@ -16,7 +16,7 @@ import {
   StorageTagsRouteParams,
   useRouteParams,
 } from '../../lib/routeParams'
-import { mdiCog, mdiMagnify } from '@mdi/js'
+import { mdiClockOutline, mdiCog, mdiMagnify } from '@mdi/js'
 import { noteDetailFocusTitleInputEventEmitter } from '../../lib/events'
 import { useTranslation } from 'react-i18next'
 import { useSearchModal } from '../../lib/searchModal'
@@ -456,6 +456,13 @@ const SidebarContainer = ({
                 labelClick: () => openTab('about'),
                 id: 'sidebar__button__members',
               },
+              {
+                label: 'Timeline',
+                icon: mdiClockOutline,
+                variant: 'transparent',
+                labelClick: () => push(getTimelineHref(workspace)),
+                id: 'sidebar__button__timeline',
+              },
             ]}
           >
             <NewDocButton workspace={workspace} />
@@ -466,6 +473,7 @@ const SidebarContainer = ({
   }, [
     activeSpace,
     openTab,
+    push,
     sidebarHeaderControls,
     toggleSearchScreen,
     workspace,

--- a/src/components/pages/StorageCreatePage.tsx
+++ b/src/components/pages/StorageCreatePage.tsx
@@ -14,7 +14,7 @@ const StorageCreatePage = () => {
           <>
             <Icon path={mdiBookPlusMultiple} size={16} />
             <span style={{ marginLeft: 10, marginRight: 10 }}>
-              Create Local Space
+              Create or import Local Space
             </span>
           </>
         ),

--- a/src/electron/updater.ts
+++ b/src/electron/updater.ts
@@ -1,6 +1,7 @@
-import { dialog, Notification, MenuItem } from 'electron'
+import { dialog, Notification, MenuItem, nativeImage, app } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import logger from 'electron-log'
+import path from 'path'
 
 autoUpdater.logger = logger
 logger.transports.file.level = 'info'
@@ -14,20 +15,24 @@ autoUpdater.on('error', (error) => {
   console.info(error.stack || error)
 })
 
+const iconPath = path.join(app.getAppPath(), './compiled/app/static/logo.png')
+
 autoUpdater.on('update-available', () => {
   foundUpdates = true
+  const appIcon = nativeImage.createFromPath(iconPath)
   if (updater == null) {
     const notification = new Notification({
-      title: 'Found Updates!',
+      title: 'BoostNote-local Found Updates!',
       body: 'Click here to update',
     })
     notification.addListener('click', () => {
       dialog
         .showMessageBox({
           type: 'info',
-          title: 'Found Updates',
-          message: 'Found updates, do you want update now?',
+          title: 'BoostNote-local Found Updates',
+          message: 'BoostNote-local found updates, do you want update now?',
           buttons: ['Sure', 'No'],
+          icon: appIcon,
         })
         .then(({ response }) => {
           if (response === 0) {
@@ -40,9 +45,11 @@ autoUpdater.on('update-available', () => {
     dialog
       .showMessageBox({
         type: 'info',
-        title: 'Found Updates',
-        message: 'Found updates, do you want update now?',
+        title: 'BoostNote-local Found Updates',
+        message:
+          'BoostNote-local found updates, do you want update BoostNote now?',
         buttons: ['Sure', 'No'],
+        icon: appIcon,
       })
       .then(({ response }) => {
         if (response === 0) {
@@ -57,9 +64,11 @@ autoUpdater.on('update-available', () => {
 
 autoUpdater.on('update-not-available', () => {
   if (updater != null) {
+    const appIcon = nativeImage.createFromPath(iconPath)
     dialog.showMessageBox({
-      title: 'No Updates',
+      title: 'BoostNote-local has no Updates',
       message: 'Current version is up-to-date.',
+      icon: appIcon,
     })
     updater.enabled = true
     updater = null
@@ -67,11 +76,13 @@ autoUpdater.on('update-not-available', () => {
 })
 
 autoUpdater.on('update-downloaded', () => {
+  const appIcon = nativeImage.createFromPath(iconPath)
   dialog
     .showMessageBox({
-      title: 'Updates downloaded',
+      title: 'BoostNote-local Updates downloaded',
       message: 'To install the update, the app must be restarted.',
       buttons: ['Restart and Install', 'Not Yet'],
+      icon: appIcon,
     })
     .then(({ response }) => {
       if (response === 0) {

--- a/src/lib/CodeMirror.ts
+++ b/src/lib/CodeMirror.ts
@@ -91,6 +91,8 @@ export const themes = [
   'shadowfox',
   'ttcn',
   'yonce',
+  'ayu-mirage',
+  'ayu-dark',
 ].sort()
 
 export interface EditorPosition {

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -210,14 +210,6 @@ export function createUnprocessableEntityError(message: string) {
   return new DbClientError(message, DbClientErrorCode.UnprocessableEntity)
 }
 
-export function createNotFoundError(message: string) {
-  return new DbClientError(message, DbClientErrorCode.NotFound)
-}
-
-export function createConflictError(message: string) {
-  return new DbClientError(message, DbClientErrorCode.Conflict)
-}
-
 export function getAllParentFolderPathnames(pathname: string) {
   const pathnames = []
   let currentPathname = pathname

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -23,6 +23,10 @@ export function keys(objectMap: ObjectMap<any>): string[] {
   return Object.keys(objectMap)
 }
 
+export function size(objectMap: ObjectMap<any>): number {
+  return values(objectMap).length
+}
+
 export function getNow(): string {
   return new Date().toISOString()
 }

--- a/src/lib/exports.ts
+++ b/src/lib/exports.ts
@@ -196,6 +196,7 @@ function getPrintStyleForExports() {
 pre code {
   white-space: pre-wrap;
 }
+
 </style>
 `
 }
@@ -216,6 +217,26 @@ async function getExportStylesInfo(
   const markdownCodeBlockTheme =
     codeBlockTheme === 'solarized-dark' ? 'solarized' : codeBlockTheme
   const appThemeCss = getGlobalCss(selectV2Theme(generalThemeName))
+  const codemirrorDefaultStylesPathPrefix = dev
+    ? `codemirror/lib/codemirror.css`
+    : `codemirror/theme/codemirror.css`
+  try {
+    const codemirrorDefaultStyles = await readFile(
+      join(cssFileRoot, codemirrorDefaultStylesPathPrefix)
+    )
+    cssStyles.push({
+      filename: 'codemirror.css',
+      content: codemirrorDefaultStyles,
+      cssLink: join(cssLinkRoot, codemirrorDefaultStylesPathPrefix),
+    })
+  } catch (err) {
+    console.warn(
+      `Cannot find asset: ${join(
+        cssFileRoot,
+        codemirrorDefaultStylesPathPrefix
+      )}`
+    )
+  }
 
   if (appThemeCss) {
     cssStyles.push({ filename: 'globalTheme.css', content: appThemeCss })

--- a/src/shared/components/atoms/GlobalStyle.tsx
+++ b/src/shared/components/atoms/GlobalStyle.tsx
@@ -72,6 +72,11 @@ scrollbar-height: 8px;
 ::-webkit-scrollbar-button {
   display: none
 }
+
+.CodeMirror {
+  height: 100%;
+}
+
 `
 
 export default createGlobalStyle<BaseTheme>`

--- a/src/shared/components/organisms/Toast.tsx
+++ b/src/shared/components/organisms/Toast.tsx
@@ -106,7 +106,7 @@ const Container = styled.div`
 
 class ToastItem extends React.Component<ToastItemProps, ToastItemState> {
   state = {
-    remaining: 3000,
+    remaining: 6000,
     timer: 0,
   }
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -63,6 +63,10 @@ module.exports = (env, argv) => {
       new CopyPlugin({
         patterns: [
           {
+            from: path.join(__dirname, 'node_modules/codemirror/lib/codemirror.css'),
+            to: 'app/codemirror/theme/codemirror.css',
+          },
+          {
             from: path.join(__dirname, 'node_modules/codemirror/theme'),
             to: 'app/codemirror/theme',
           },


### PR DESCRIPTION
Fix sidebar on no spaces and create space on no spaces

Improve timeout for push message (from 3s to 6s)
Fix selecting non-existing space leading to 404 instead of push message
Add size util method for getting ObjectMap size
Fix PDF export not containing default CodeMirror styles
Add ayu mirage themes for CodeMirror and markdown
Fix global style to include CodeMirror restriction (needed for export)

Improve updater

Improve updater descriptions
Add logo to message dialogs for the updater
Update changelog

Fixes: #44, #40

Tests:
Updater tested on Windows
PDF export tested on Windows and Linux (production and dev versions)
Tested space creation handling on Windows and Linux

