### PR TITLE
Add enlarge image in Markdown Preview and Attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ For more info on features and upcoming changes, please visit our [Open Issues](h
 ### Added
 
 - The welcome note on space creation or import
+- Markdown Preview option to enlarge image on click
+- Attachments page enlarge image on click
 
 ### Fixed
 
 - Space navigation on space remove (defaults to first available space)
 - Focus title not working
 - Auto-focus on opening rename or other modal dialogs with form inputs
+- Attachments context menu open button not working (open on disk works now)
 
 ## [Released]
 

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -28,6 +28,7 @@ import {
 import { rehypePosition } from '../../lib/markdown/rehypePosition'
 import styled from '../../shared/lib/styled'
 import rehypeCodeMirror from '../../shared/lib/codemirror/rehypeCodeMirror'
+import ExpandableImage from '../molecules/Image/ExpandableImage'
 
 const schema = mergeDeepRight(gh, {
   attributes: {
@@ -94,7 +95,7 @@ const MarkdownPreviewer = ({
           }
         }
 
-        return <img {...props} src={src} />
+        return <ExpandableImage {...props} src={src} />
       },
       a: ({ href, children }: any) => {
         return (

--- a/src/components/atoms/markdown/AttachmentImage.tsx
+++ b/src/components/atoms/markdown/AttachmentImage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react'
 import { Attachment, AttachmentData } from '../../../lib/db/types'
+import ExpandableImage from '../../molecules/Image/ExpandableImage'
 
 interface AttachmentImageProps {
   attachment: Attachment
@@ -8,6 +9,7 @@ interface AttachmentImageProps {
 
 const AttachmentImage = ({ attachment, ...props }: AttachmentImageProps) => {
   const [data, setData] = useState<AttachmentData | null>(null)
+
   useEffect(() => {
     attachment.getData().then((data) => {
       setData(data)
@@ -35,7 +37,7 @@ const AttachmentImage = ({ attachment, ...props }: AttachmentImageProps) => {
     return null
   }
 
-  return <img src={src} {...props} />
+  return <ExpandableImage src={src} {...props} />
 }
 
 export default AttachmentImage

--- a/src/components/molecules/Image/ExpandableImage.tsx
+++ b/src/components/molecules/Image/ExpandableImage.tsx
@@ -1,0 +1,102 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import ImagePreview from './ImagePreview'
+import { useModal } from '../../../shared/lib/stores/modal'
+import {
+  isSingleKeyEventOutsideOfInput,
+  preventKeyboardEventPropagation,
+  useGlobalKeyDownHandler,
+} from '../../../shared/lib/keyboard'
+import Icon from '../../../shared/components/atoms/Icon'
+import { mdiArrowExpandAll } from '@mdi/js'
+import Image from '../../atoms/Image'
+import styled from '../../../shared/lib/styled'
+import { flexCenter } from '../../../shared/lib/styled/styleFunctions'
+
+interface ExpandableImageProps {
+  src: string
+}
+
+const ExpandableImage = ({ src }: ExpandableImageProps) => {
+  const [isHovered, setIsHovered] = useState<boolean>(false)
+  const [showingEnlargedImage, setShowingEnlargedImage] = useState<boolean>(
+    false
+  )
+  const { closeLastModal, openModal } = useModal()
+  const onImageExpand = useCallback(() => {
+    closeLastModal()
+
+    openModal(<ImagePreview src={src} />, {
+      showCloseIcon: true,
+      hideBackground: true,
+      width: 'full',
+    })
+    setShowingEnlargedImage(true)
+  }, [closeLastModal, openModal, src])
+
+  const keydownHandler = useMemo(() => {
+    return (event: KeyboardEvent) => {
+      if (
+        isSingleKeyEventOutsideOfInput(event, 'escape') &&
+        showingEnlargedImage
+      ) {
+        preventKeyboardEventPropagation(event)
+        closeLastModal()
+      }
+    }
+  }, [closeLastModal, showingEnlargedImage])
+  useGlobalKeyDownHandler(keydownHandler)
+
+  return (
+    <ImageContainer
+      onClick={() => onImageExpand()}
+      onMouseOver={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <Image src={src} />
+
+      {isHovered && (
+        <>
+          <ImageActionButton
+            onClick={() => {
+              onImageExpand()
+            }}
+          >
+            <Icon path={mdiArrowExpandAll} />
+          </ImageActionButton>
+        </>
+      )}
+    </ImageContainer>
+  )
+}
+
+const ImageContainer = styled.span`
+  position: relative;
+  cursor: pointer;
+  display: block;
+`
+
+const ImageActionButton = styled.button`
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 30px;
+  width: 30px;
+  box-sizing: border-box;
+  font-size: 18px;
+  outline: none;
+  background-color: rgba(0, 0, 0, 0.3);
+  ${flexCenter};
+  border: none;
+  cursor: pointer;
+  transition: color 200ms ease-in-out;
+  color: ${({ theme }) => theme.colors.text.primary};
+  &:hover {
+    color: ${({ theme }) => theme.colors.text.link};
+  }
+  &:active,
+  &.active {
+    color: ${({ theme }) => theme.colors.text.subtle};
+  }
+`
+
+export default ExpandableImage

--- a/src/components/molecules/Image/ImagePreview.tsx
+++ b/src/components/molecules/Image/ImagePreview.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import Image from '../../atoms/Image'
+import styled from '../../../shared/lib/styled'
+
+interface ImagePreviewProps {
+  src: string
+}
+
+const ImagePreview = ({ src }: ImagePreviewProps) => {
+  return (
+    <Container>
+      <Image className={'image__preview_width'} src={src} />
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  padding: 20px 25px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  .image__preview_width {
+    max-width: 100%;
+  }
+`
+
+export default ImagePreview

--- a/src/components/organisms/ArchiveDetail.tsx
+++ b/src/components/organisms/ArchiveDetail.tsx
@@ -68,6 +68,14 @@ const ArchiveDetail = ({ storage }: TrashDetailProps) => {
     [setPreferences]
   )
 
+  if (notes.length === 0) {
+    return (
+      <NoArchivedItemsContainer>
+        No archived documents, please archive some to see them here.
+      </NoArchivedItemsContainer>
+    )
+  }
+
   return (
     <PageContainer>
       <Header>
@@ -100,6 +108,10 @@ const ArchiveDetail = ({ storage }: TrashDetailProps) => {
 }
 
 export default ArchiveDetail
+
+const NoArchivedItemsContainer = styled.div`
+  margin: 1em;
+`
 
 const Header = styled.h1`
   display: flex;

--- a/src/components/pages/AttachmentsPage.tsx
+++ b/src/components/pages/AttachmentsPage.tsx
@@ -64,7 +64,7 @@ const AttachmentsPage = ({ storage }: AttachmentsPageProps) => {
       >
         <PageDraggableHeader
           iconPath={mdiPaperclip}
-          label={`Attachments in ${storage.name}`}
+          label={`Attachments in space ${storage.name}`}
         />
 
         <AttachmentList workspace={storage} />

--- a/src/shared/components/organisms/Modal/index.tsx
+++ b/src/shared/components/organisms/Modal/index.tsx
@@ -72,7 +72,16 @@ const ContextModalItem = ({
   const style: CSSProperties | undefined = useMemo(() => {
     const properties: CSSProperties = {
       width: modalWidth,
-      maxHeight: windowHeight - (modal.position?.bottom || 0) - 10,
+      height: modal.height,
+      maxHeight:
+        modal.position?.alignment === 'bottom-left' ||
+        modal.position?.alignment === 'bottom-right'
+          ? windowHeight - (modal.position?.bottom || 0) - 10
+          : modal.maxHeight != null
+          ? modal.maxHeight
+          : (modal.position?.top || 0) -
+            ((modal.position?.bottom || 0) - (modal.position?.top || 0)) -
+            10,
     }
 
     if (modal.position != null) {
@@ -96,19 +105,35 @@ const ContextModalItem = ({
       }
     }
 
+    if (properties.maxHeight! < 80) {
+      properties.minHeight = 100
+      properties.maxHeight = 200
+      properties.top = undefined
+      properties.bottom = 6
+    }
+
     return properties
-  }, [modal.position, windowWidth, modalWidth, windowHeight])
+  }, [
+    modalWidth,
+    modal.height,
+    modal.position,
+    modal.maxHeight,
+    windowHeight,
+    windowWidth,
+  ])
 
   return (
     <>
       <div className='modal__window__scroller'>
-        <div className='modal__bg__hidden' onClick={closeModal}></div>
+        <div className='modal__bg__hidden' onClick={closeModal} />
         <div className='modal__window__anchor' />
         <VerticalScroller
           className={cc([
             'modal__window',
             `modal__window__width--${modal.width}`,
             modal.position != null && `modal__window--context`,
+            modal.hideBackground && 'modal__window--no-bg',
+            modal.removePadding && 'modal__window--no-padding',
           ])}
           style={style}
         >
@@ -157,6 +182,7 @@ const ModalItem = ({
         className={cc([
           'modal__window',
           `modal__window__width--${modal.width}`,
+          modal.hideBackground && 'modal__window--no-bg',
           modal.position != null && `modal__window--context`,
         ])}
       >
@@ -196,6 +222,15 @@ const Container = styled.div`
     opacity: 0.7;
   }
 
+  .modal__window--no-bg {
+    background: none !important;
+  }
+
+  .modal__window--context.modal__window--no-padding,
+  .modal__window--context.modal__window--no-padding .modal__wrapper {
+    padding: 0 !important;
+  }
+
   .modal__bg__hidden {
     z-index: ${zIndexModals + 1};
     position: fixed;
@@ -224,8 +259,9 @@ const Container = styled.div`
 
   .modal__window--context {
     border: 1px solid ${({ theme }) => theme.colors.border.main};
+    height: auto !important;
+    position: fixed !important;
     margin: 0 !important;
-    bottom: 0;
     right: 0;
     left: 0;
     background-color: ${({ theme }) =>
@@ -255,6 +291,10 @@ const Container = styled.div`
 
     &.modal__window__width--large {
       width: 1100px;
+    }
+
+    &.modal__window__width--full {
+      width: 100%;
     }
   }
 

--- a/src/shared/lib/stores/modal/types.ts
+++ b/src/shared/lib/stores/modal/types.ts
@@ -4,7 +4,9 @@ export interface ModalElement {
   title?: React.ReactNode
   content: React.ReactNode
   showCloseIcon?: boolean
-  width: 'large' | 'default' | 'small' | number
+  width: 'large' | 'default' | 'small' | 'full' | number
+  height?: number
+  maxHeight?: number
   position?: {
     left: number
     right: number
@@ -12,6 +14,8 @@ export interface ModalElement {
     bottom: number
     alignment: ContextModalAlignment
   }
+  hideBackground?: boolean
+  removePadding?: boolean
   onClose?: () => void
 }
 
@@ -19,13 +23,15 @@ export type ContextModalAlignment = 'bottom-left' | 'bottom-right'
 export type ModalOpeningOptions = {
   showCloseIcon?: boolean
   keepAll?: boolean
-  width?: 'large' | 'default' | 'small' | number
+  width?: 'large' | 'default' | 'small' | 'full' | number
+  hideBackground?: boolean
   title?: string
   onClose?: () => void
 }
 
 export type ContextModalOpeningOptions = ModalOpeningOptions & {
   alignment?: ContextModalAlignment
+  hideBackground?: boolean
 }
 
 export interface ModalsContext {


### PR DESCRIPTION
Add enlarge image in Markdown preview and attachments page
Fix attachments not showing nice message when no attachments are in a space
Fix archived documents page not showing nice message when no notes are archived
Fix preview and right click buttons on attachments page
- attachments no longe in one row
- attachments a bit bigger
- attachments open context menu option not working (open in file system)

Fixes: #49 