### PR TITLE
Add initial open note-link functionality

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -53,6 +53,7 @@ Finally, users can add attachments and charts ([PlantUML](https://plantuml.com/)
     - Supports case sensitive search
     - Supports multiline search
     - Supports keyboard navigation
+  - Link between notes
 - Side Navigator
   - Folder hierarchy
   - Supports Drag and Drop

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -113,16 +113,23 @@ const App = () => {
           }
         }
 
-        getNotePathname(noteStorageId, noteIdWithPrefix).then((pathname) => {
-          if (pathname) {
-            replace(getNoteFullItemId(noteStorageId, pathname, noteId))
-          } else {
+        getNotePathname(noteStorageId, noteIdWithPrefix)
+          .then((pathname) => {
+            if (pathname) {
+              replace(getNoteFullItemId(noteStorageId, pathname, noteId))
+            } else {
+              pushMessage({
+                title: 'Note link invalid!',
+                description: 'The note link you are trying to open is invalid.',
+              })
+            }
+          })
+          .catch(() => {
             pushMessage({
               title: 'Note link invalid!',
               description: 'The note link you are trying to open is invalid.',
             })
-          }
-        })
+          })
       }
     }
     addIpcListener('note:navigate', noteLinkNavigateEventHandler)

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -102,26 +102,34 @@ const App = () => {
           description: 'Cannot open note link without storage information.',
         })
       } else {
-        getNotePathname(activeStorageId, prependNoteIdPrefix(noteId)).then(
-          (pathname) => {
-            if (pathname) {
-              replace(getNoteFullItemId(activeStorageId, pathname, noteId))
-            } else {
-              pushMessage({
-                title: 'Note link invalid!',
-                description:
-                  'The note link you are trying to open is invalid or from another storage.',
-              })
+        const noteIdWithPrefix = prependNoteIdPrefix(noteId)
+        let noteStorageId = activeStorageId
+        if (storageMap != null) {
+          for (const storage of values(storageMap)) {
+            if (storage.noteMap[noteIdWithPrefix] != null) {
+              noteStorageId = storage.id
+              break
             }
           }
-        )
+        }
+
+        getNotePathname(noteStorageId, noteIdWithPrefix).then((pathname) => {
+          if (pathname) {
+            replace(getNoteFullItemId(noteStorageId, pathname, noteId))
+          } else {
+            pushMessage({
+              title: 'Note link invalid!',
+              description: 'The note link you are trying to open is invalid.',
+            })
+          }
+        })
       }
     }
     addIpcListener('note:navigate', noteLinkNavigateEventHandler)
     return () => {
       removeIpcListener('note:navigate', noteLinkNavigateEventHandler)
     }
-  }, [activeStorageId, getNotePathname, pushMessage, replace])
+  }, [activeStorageId, getNotePathname, pushMessage, replace, storageMap])
 
   useEffect(() => {
     const preferencesIpcEventHandler = () => {

--- a/src/components/atoms/CodeEditor.tsx
+++ b/src/components/atoms/CodeEditor.tsx
@@ -53,6 +53,16 @@ const StyledContainer = styled.div`
       theme.codeEditorSelectedTextBackgroundColor};
     border: 1px solid #fffae3;
   }
+
+  .CodeMirror-hyperlink {
+    cursor: pointer;
+  }
+
+  .CodeMirror-hover {
+    padding: 2px 4px 0 4px;
+    position: absolute;
+    z-index: 99;
+  }
 `
 
 const defaultCodeMirrorOptions: CodeMirror.EditorConfiguration = {

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -114,6 +114,7 @@ const MarkdownPreviewer = ({
       a: ({ href, children }: any) => {
         return (
           <a
+            className={'markdown__custom__note_link'}
             href={href}
             onClick={(event) => {
               event.preventDefault()

--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -178,16 +178,23 @@ const MarkdownPreviewer = ({
           }
         }
 
-        getNotePathname(noteStorageId, noteIdWithPrefix).then((pathname) => {
-          if (pathname) {
-            replace(getNoteFullItemId(noteStorageId, pathname, noteId))
-          } else {
+        getNotePathname(noteStorageId, noteIdWithPrefix)
+          .then((pathname) => {
+            if (pathname) {
+              replace(getNoteFullItemId(noteStorageId, pathname, noteId))
+            } else {
+              pushMessage({
+                title: 'Note link invalid!',
+                description: 'The note link you are trying to open is invalid.',
+              })
+            }
+          })
+          .catch(() => {
             pushMessage({
               title: 'Note link invalid!',
               description: 'The note link you are trying to open is invalid.',
             })
-          }
-        })
+          })
       }
     },
     [activeStorageId, pushMessage, storageMap, getNotePathname, replace]

--- a/src/components/organisms/SidebarContainer.tsx
+++ b/src/components/organisms/SidebarContainer.tsx
@@ -38,6 +38,7 @@ import SidebarHeader, {
   SidebarControls,
 } from '../../shared/components/organisms/Sidebar/atoms/SidebarHeader'
 import SidebarButtonList from '../../shared/components/organisms/Sidebar/molecules/SidebarButtonList'
+import { useToast } from '../../shared/lib/stores/toast'
 
 interface SidebarContainerProps {
   workspace?: NoteStorage
@@ -62,6 +63,7 @@ const SidebarContainer = ({
     deleteFolderApi,
     toggleDocArchived,
     toggleDocBookmark,
+    copyNoteLink,
   } = useLocalDB()
   const {
     openWorkspaceEditForm,
@@ -82,6 +84,8 @@ const SidebarContainer = ({
     unfoldItem,
     foldItem,
   } = useSidebarCollapse()
+
+  const { pushMessage } = useToast()
 
   const localSpaces = useMemo(() => values(storageMap), [storageMap])
 
@@ -312,7 +316,9 @@ const SidebarContainer = ({
       dropInDocOrFolder,
       openRenameFolderForm,
       openRenameDocForm,
-      exportDocuments
+      exportDocuments,
+      copyNoteLink,
+      pushMessage
     )
   }, [
     workspace,
@@ -334,6 +340,8 @@ const SidebarContainer = ({
     openRenameFolderForm,
     openRenameDocForm,
     exportDocuments,
+    copyNoteLink,
+    pushMessage,
   ])
 
   const sidebarHeaderControls: SidebarControls = useMemo(() => {

--- a/src/lib/addons/hyperlink.js
+++ b/src/lib/addons/hyperlink.js
@@ -1,0 +1,186 @@
+import { openExternal, getWebContentsById } from '../electronOnly'
+import { osName } from '../platform'
+
+export function initHyperlink(CodeMirror) {
+  const eventEmitter = {
+    emit: function (eventType, href) {
+      const webContents = getWebContentsById(1)
+      if (webContents) {
+        webContents.send(eventType, href)
+      } else {
+        console.log('[DEBUG]: No window for web contents id:1')
+      }
+    },
+  }
+  const yOffset = 2
+
+  const macOS = osName === 'macos'
+  const modifier = macOS ? 'metaKey' : 'ctrlKey'
+
+  class HyperLink {
+    constructor(cm) {
+      this.cm = cm
+      this.lineDiv = cm.display.lineDiv
+
+      this.onMouseDown = this.onMouseDown.bind(this)
+      this.onMouseEnter = this.onMouseEnter.bind(this)
+      this.onMouseLeave = this.onMouseLeave.bind(this)
+      this.onMouseMove = this.onMouseMove.bind(this)
+
+      this.tooltip = document.createElement('div')
+      this.tooltipContent = document.createElement('div')
+      this.tooltipIndicator = document.createElement('div')
+      this.tooltip.setAttribute(
+        'class',
+        'CodeMirror-hover CodeMirror-matchingbracket CodeMirror-selected'
+      )
+      this.tooltip.setAttribute('cm-ignore-events', 'true')
+      this.tooltip.appendChild(this.tooltipContent)
+      this.tooltip.appendChild(this.tooltipIndicator)
+      this.tooltipContent.textContent = `${
+        macOS ? 'Cmd(⌘)' : 'Ctrl(^)'
+      } + click to follow link`
+
+      this.lineDiv.addEventListener('mousedown', this.onMouseDown)
+      this.lineDiv.addEventListener('mouseenter', this.onMouseEnter, {
+        capture: true,
+        passive: true,
+      })
+      this.lineDiv.addEventListener('mouseleave', this.onMouseLeave, {
+        capture: true,
+        passive: true,
+      })
+      this.lineDiv.addEventListener('mousemove', this.onMouseMove, {
+        passive: true,
+      })
+    }
+
+    getUrl(el) {
+      const className = el.className.split(' ')
+      if (className.indexOf('cm-url') !== -1) {
+        // multiple cm-url because of search term
+        const cmUrlSpans = Array.from(
+          el.parentNode.getElementsByClassName('cm-url')
+        )
+        const textContent =
+          cmUrlSpans.length > 1
+            ? cmUrlSpans.map((span) => span.textContent).join('')
+            : el.textContent
+
+        const match = /^\((.*)\)|\[(.*)]|(.*)$/.exec(textContent)
+        const url = match[1] || match[2] || match[3]
+        return /^:storage(?:\/|%5C)/.test(url) ? null : url
+      }
+
+      return null
+    }
+
+    specialLinkHandler(e, rawHref, linkHash) {
+      // This wil match shortId note id
+      // :note:cs23_d12 up to :note:cs23_d122bgCol
+      const regexIsNoteShortIdLink = /^:note:([a-zA-Z0-9_\-]{7,14})$/
+      if (regexIsNoteShortIdLink.test(linkHash)) {
+        eventEmitter.emit('note:navigate', linkHash.replace(':note:', ''))
+        return true
+      }
+
+      return false
+    }
+
+    onMouseDown(e) {
+      const { target } = e
+      if (!e[modifier]) {
+        return
+      }
+
+      // Create URL spans array used for special case "search term is hitting a link".
+      const cmUrlSpans = Array.from(
+        e.target.parentNode.getElementsByClassName('cm-url')
+      )
+
+      const innerText =
+        cmUrlSpans.length > 1
+          ? cmUrlSpans.map((span) => span.textContent).join('')
+          : e.target.innerText
+      const rawHref = innerText.trim().slice(1, -1) // get link text from markdown text
+
+      if (!rawHref) return // not checked href because parser will create file://... string for [empty link]()
+
+      const parser = document.createElement('a')
+      parser.href = rawHref
+      const { href, hash } = parser
+      // needed because we're having special link formats that are removed by parser e.g. :line:10
+      const linkHash = hash === '' ? rawHref : hash
+      const foundUrl = this.specialLinkHandler(target, rawHref, linkHash)
+
+      if (!foundUrl) {
+        const url = this.getUrl(target)
+        // all special cases handled --> other case
+        if (url) {
+          e.preventDefault()
+          openExternal(url)
+        }
+      }
+    }
+
+    onMouseEnter(e) {
+      const { target } = e
+
+      const url = this.getUrl(target)
+      if (url) {
+        if (e[modifier]) {
+          target.classList.add(
+            'CodeMirror-activeline-background',
+            'CodeMirror-hyperlink'
+          )
+        } else {
+          target.classList.add('CodeMirror-activeline-background')
+        }
+
+        this.showInfo(target)
+      }
+    }
+
+    onMouseLeave(e) {
+      if (this.tooltip.parentElement === this.lineDiv) {
+        e.target.classList.remove(
+          'CodeMirror-activeline-background',
+          'CodeMirror-hyperlink'
+        )
+
+        this.lineDiv.removeChild(this.tooltip)
+      }
+    }
+
+    onMouseMove(e) {
+      if (this.tooltip.parentElement === this.lineDiv) {
+        if (e[modifier]) {
+          e.target.classList.add('CodeMirror-hyperlink')
+        } else {
+          e.target.classList.remove('CodeMirror-hyperlink')
+        }
+      }
+    }
+
+    showInfo(relatedTo) {
+      const b1 = relatedTo.getBoundingClientRect()
+      const b2 = this.lineDiv.getBoundingClientRect()
+      const tdiv = this.tooltip
+
+      tdiv.style.left = b1.left - b2.left + 'px'
+      this.lineDiv.appendChild(tdiv)
+
+      const b3 = tdiv.getBoundingClientRect()
+      const top = b1.top - b2.top - b3.height - yOffset
+      if (top < 0) {
+        tdiv.style.top = b1.top - b2.top + b1.height + yOffset + 'px'
+      } else {
+        tdiv.style.top = top + 'px'
+      }
+    }
+  }
+
+  CodeMirror.defineOption('hyperlink', true, (cm) => {
+    const addon = new HyperLink(cm)
+  })
+}

--- a/src/lib/db/FSNoteDb.ts
+++ b/src/lib/db/FSNoteDb.ts
@@ -296,6 +296,13 @@ class FSNoteDb implements NoteDb {
     await unlinkFile(attachmentPathname)
   }
 
+  async copyNoteLink(noteId: string, noteProps: Partial<NoteDocEditibleProps>) {
+    const noteLink = `[${escapeRegExp(
+      noteProps.title ? noteProps.title : 'Untitled'
+    )}](:${noteId})`
+    return noteLink
+  }
+
   async createNote(
     noteProps: Partial<NoteDocEditibleProps | NoteDocImportableProps>
   ) {

--- a/src/lib/db/consts.ts
+++ b/src/lib/db/consts.ts
@@ -2,3 +2,5 @@ export const FOLDER_ID_PREFIX = 'folder:'
 export const NOTE_ID_PREFIX = 'note:'
 export const TAG_ID_PREFIX = 'tag:'
 export const ATTACHMENTS_ID = 'attachments'
+export const NOTE_LINK_SHORT_ID_REGEXP = /^[a-zA-Z0-9_\-]{7,14}$/
+export const NOTE_LINK_PREFIX_AND_SHORT_ID_REGEXP = /\((:note:)([a-zA-Z0-9_\-]{7,14})\)/g

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -1,4 +1,10 @@
-import { NOTE_ID_PREFIX, FOLDER_ID_PREFIX, TAG_ID_PREFIX } from './consts'
+import {
+  NOTE_ID_PREFIX,
+  FOLDER_ID_PREFIX,
+  TAG_ID_PREFIX,
+  NOTE_LINK_SHORT_ID_REGEXP,
+  NOTE_LINK_PREFIX_AND_SHORT_ID_REGEXP,
+} from './consts'
 import { join } from 'path'
 import {
   ObjectMap,
@@ -104,6 +110,24 @@ export function getFolderName(
     return folderName
   }
   return fallback
+}
+
+export function prependNoteIdPrefix(noteId: string): string {
+  if (new RegExp(`^${NOTE_ID_PREFIX}`).test(noteId)) {
+    return noteId
+  }
+  return `${NOTE_ID_PREFIX}${noteId}`
+}
+
+export function isNoteLinkId(href: string): boolean {
+  return NOTE_LINK_SHORT_ID_REGEXP.test(href)
+}
+
+export function removePrefixFromNoteLinks(content: string): string {
+  if (NOTE_LINK_PREFIX_AND_SHORT_ID_REGEXP.test(content)) {
+    return content.replace(NOTE_LINK_PREFIX_AND_SHORT_ID_REGEXP, '($2)')
+  }
+  return content
 }
 
 export function getFolderId(pathname: string): string {

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -1,3 +1,16 @@
+export function getNoteFullItemId(
+  storageId: string,
+  pathname: string,
+  noteId: string
+) {
+  const notePathname = pathname.startsWith('/')
+    ? pathname.substring(1)
+    : pathname
+  return `/app/storages/${storageId}/notes/${notePathname}${
+    notePathname === '' ? '' : '/'
+  }note:${noteId}`
+}
+
 export function getStorageItemId(storageId: string) {
   return `storage:${storageId}`
 }

--- a/src/lib/preview.ts
+++ b/src/lib/preview.ts
@@ -440,6 +440,11 @@ hr {
   border-color: rgba(255,255,255,0.3);
   color: #36abe3;
 }
+
+.dark .markdown__custom__note_link  {
+  color: #2886ef;
+}
+
 `
 
 function loadPreviewStyle() {

--- a/src/lib/v2/hooks/useLocalDB.ts
+++ b/src/lib/v2/hooks/useLocalDB.ts
@@ -28,6 +28,7 @@ export function useLocalDB() {
     renameFolder,
     updateFolderOrderedIds,
     storageMap: workspaceMap,
+    copyNoteLink,
   } = useDb()
   const { push } = useRouter()
 
@@ -230,6 +231,7 @@ export function useLocalDB() {
     renameFolderApi,
     updateFolderOrderedIdsApi,
     workspaceMap,
+    copyNoteLink,
   }
 }
 

--- a/src/lib/v2/mappers/local/sidebarTree.tsx
+++ b/src/lib/v2/mappers/local/sidebarTree.tsx
@@ -59,7 +59,6 @@ import {
 } from '../../../../shared/components/organisms/Sidebar/molecules/SidebarTree'
 import { FOLDER_ID_PREFIX } from '../../../db/consts'
 import copy from 'copy-to-clipboard'
-import { ToastMessage } from '../../../../shared/lib/stores/toast'
 
 type LocalTreeItem = {
   id: string
@@ -401,6 +400,7 @@ export function mapTree(
             if (noteLink) {
               copy(noteLink)
               pushMessage({
+                type: 'success',
                 title: 'Note Link Copied',
                 description: 'Paste note link in any note to add a link to it',
               })

--- a/src/lib/v2/mappers/local/sidebarTree.tsx
+++ b/src/lib/v2/mappers/local/sidebarTree.tsx
@@ -9,6 +9,7 @@ import {
   mdiFileDocumentOutline,
   mdiTextBoxPlus,
   mdiFolderPlusOutline,
+  mdiLinkVariant,
   mdiPaperclip,
   mdiPencil,
   mdiStar,
@@ -22,6 +23,7 @@ import React from 'react'
 import {
   FolderDoc,
   NoteDoc,
+  NoteDocEditibleProps,
   NoteStorage,
   ObjectMap,
   TagDoc,
@@ -56,6 +58,8 @@ import {
   SidebarTreeChildRow,
 } from '../../../../shared/components/organisms/Sidebar/molecules/SidebarTree'
 import { FOLDER_ID_PREFIX } from '../../../db/consts'
+import copy from 'copy-to-clipboard'
+import { ToastMessage } from '../../../../shared/lib/stores/toast'
 
 type LocalTreeItem = {
   id: string
@@ -206,7 +210,13 @@ export function mapTree(
   exportDocuments: (
     workspace: NoteStorage,
     exportSettings: LocalExportResourceRequestBody
-  ) => void
+  ) => void,
+  copyNoteLink: (
+    storageId: string,
+    noteId: string,
+    noteProps: Partial<NoteDocEditibleProps>
+  ) => Promise<string | undefined>,
+  pushMessage: (context: any) => any
 ): SidebarNavCategory[] | undefined {
   if (!initialLoadDone || workspace == null) {
     return undefined
@@ -378,6 +388,30 @@ export function mapTree(
           icon: mdiArchiveOutline,
           label: doc.trashed ? 'Restore' : 'Archive',
           onClick: () => toggleNoteArchived(workspace.id, noteId, doc.trashed),
+        },
+        {
+          type: MenuTypes.Normal,
+          icon: mdiLinkVariant,
+          label: 'Copy note link',
+          onClick: async () => {
+            const noteLink = await copyNoteLink(workspace.id, noteId, {
+              title: getNoteTitle(doc, 'Untitled'),
+              folderPathname: doc.folderPathname,
+            })
+            if (noteLink) {
+              copy(noteLink)
+              pushMessage({
+                title: 'Note Link Copied',
+                description: 'Paste note link in any note to add a link to it',
+              })
+            } else {
+              pushMessage({
+                title: 'Note Link Error',
+                description:
+                  'An error occurred while attempting to create a note link',
+              })
+            }
+          },
         },
       ],
       parentId: parentNoteId,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*.ts", "src/**/*.tsx", "typings/**/*.d.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "typings/**/*.d.ts", "src/lib/addons/*.js"],
   "exclude": ["dist", "node_modules"],
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Overview

I pulled in the changes that @Komediruzecki had originally proposed in https://github.com/BoostIO/BoostNote-App/pull/691.

I updated the patch for all the recent changes, including moving the context menu from the old API to V2.

## Preview

This preview is from testing with the local development setup.

![Peek 2022-02-26 14-50](https://user-images.githubusercontent.com/5495776/155857143-6bbcd16b-3ec6-4d63-99f4-4c5eb8a7c243.gif)

## Detailed Changelog

```
Based on https://github.com/BoostIO/BoostNote-App/pull/691

Changes pulled in from original patch:

- Update db API for creating a note link (createstore, FSNoteDb)
- Add codemirror hyperlink addon
- Initialize hyperlink addon (CodeMirror.ts)
- Add event handling of editor ctrl+click link with ipc (App.tsx)
- Add regexes for note link shortId (MarkdownPreviewer.tsx)
- Add handling of rendering and clicking of note link in md preview
- Fix electron only API
- Fix getWebContentsById to be initialized
- Fix hyperlink to use electron only API
- Fix macos binding in hyperlink
- Refactor utility functions and put regexes in constants
- Fix note linking when title contains characters that should be escaped
- Add note link copied push message
- Add push message when note link is successfully copied
- Fix issues with event default propagation on context menu

Differences from original patch:

- Removed PouchNoteDb support
- Migrated to V2 API for context menu in sidebar
- Removed codemirror hyperlink addon css style (CodeEditor.tsx)
```