### PR TITLE
Add close window custom keymap

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -26,6 +26,7 @@ const keymap = new Map<string, string>([
   ['toggleSplitEditMode', 'Ctrl + \\'],
   ['togglePreviewMode', 'Ctrl + E'],
   ['editorSaveAs', 'Ctrl + S'],
+  ['closeWindow', 'Ctrl + W'],
 ])
 
 function applyMenuTemplate(template: MenuItemConstructorOptions[]) {

--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -298,9 +298,9 @@ export function getTemplateFromKeymap(
               { type: 'separator' },
               { role: 'front' },
               { type: 'separator' },
-              { role: 'window' },
+              { role: 'window', accelerator: keymap.get('closeWindow') },
             ]
-          : [{ role: 'close' }]),
+          : [{ role: 'close', accelerator: keymap.get('closeWindow') }]),
       ] as MenuItemConstructorOptions[],
     },
     {

--- a/src/lib/keymap.ts
+++ b/src/lib/keymap.ts
@@ -158,6 +158,23 @@ export const defaultKeymap = new Map<string, KeymapItem>([
       isMenuType: false,
     },
   ],
+  [
+    'closeWindow',
+    {
+      shortcutMainStroke: {
+        key: 'W',
+        keycode: 87,
+        modifiers:
+          osName === 'macos'
+            ? { meta: true }
+            : {
+                ctrl: true,
+              },
+      },
+      description: 'Closes currently opened window',
+      isMenuType: true,
+    },
+  ],
 ])
 
 export function compareEventKeyWithKeymap(


### PR DESCRIPTION
Add close window keymap option

Un-assign to remove, assign to another keymap to change

Fixes: https://github.com/BoostIO/BoostNote.next-local/issues/83