### PR TITLE
Add Node.js 16 prerequisite to readme and package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   ],
   "author": "Junyoung Choi <fluke8259@gmail.com>",
   "license": "GPL-3.0",
+  "engines": {
+    "node": "16.x"
+  },
   "devDependencies": {
     "@babel/core": "^7.6.0",
     "@babel/plugin-proposal-class-properties": "^7.5.5",

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,15 @@ Standalone app separated from Boost Note for better local space support. See [Ro
 - `electron` : Compiled electron resources from `npm run build:electron` script. You can run it by `npm start` script. The resources are for packaging the electron app.
 - `src` : Source code.
 
+### Prerequisites
+
+- Node.js 16.x — newer versions are not supported
+
+```sh
+nvm install 16
+nvm use 16
+```
+
 ### Build
 
 Please copy `.env.default` file and create a file named `.env` in the root of the project directory, or the build will fail.
@@ -49,7 +58,7 @@ Please copy `.env.default` file and create a file named `.env` in the root of th
 
 ```sh
 # Install dependencies
-npm i
+npm install
 
 # Run webpack
 npm run dev:webpack


### PR DESCRIPTION
The program doesn't run with Node 17 or newer. It took me an hour to realize that was why it was not possible to build the project. It runs perfectly in Node 16. So I think it is important to let people know that, to save them time and prevent them from giving up on building the code over such a minor issue.

Ideally, in the future the code could be updated to support the latest Node version. It would probably also be good practice to always specify a recommended Node version for compiling.