### PR TITLE
Feat/update node and other deps

### DIFF
--- a/src/components/atoms/MarkdownPreviewer.tsx
+++ b/src/components/atoms/MarkdownPreviewer.tsx
@@ -92,73 +92,10 @@ const MarkdownPreviewer = ({
   const activeStorageId = useActiveStorageId()
   const { pushMessage } = useToast()
 
-  const remarkAdmonitionOptions = {
-    tag: ':::',
-    icons: 'emoji',
-    infima: false,
-  }
-
-  const rehypeReactConfig = {
-    createElement: React.createElement,
-    Fragment: React.Fragment,
-    components: {
-      img: ({ src, ...props }: any) => {
-        if (src != null && !src.match('/')) {
-          const attachment = attachmentMap[src]
-          if (attachment != null) {
-            return <AttachmentImage attachment={attachment} {...props} />
-          }
-        }
-
-        return <ExpandableImage {...props} src={src} />
-      },
-      a: ({ href, children }: any) => {
-        return (
-          <a
-            className={'markdown__custom__note_link'}
-            href={href}
-            onClick={(event) => {
-              event.preventDefault()
-              if (href) {
-                if (isNoteLinkId(href)) {
-                  navigateToNote(href)
-                } else {
-                  openNew(href)
-                }
-              }
-            }}
-          >
-            {children}
-          </a>
-        )
-      },
-      input: (props: React.HTMLProps<HTMLInputElement>) => {
-        const { type, checked } = props
-
-        if (type !== 'checkbox') {
-          return <input {...props} />
-        }
-
-        return (
-          <MarkdownCheckbox
-            index={checkboxIndexRef.current++}
-            checked={checked}
-            updateContent={updateContent}
-          />
-        )
-      },
-      pre: CodeFence,
-      flowchart: ({ children }: any) => {
-        return <Flowchart code={children[0]} />
-      },
-      chart: ({ children }: any) => {
-        return <Chart config={children[0]} />
-      },
-      'chart(yaml)': ({ children }: any) => {
-        return <Chart config={children[0]} isYml={true} />
-      },
-    },
-  }
+  const remarkAdmonitionOptions = useMemo(
+    () => ({ tag: ':::', icons: 'emoji', infima: false }),
+    []
+  )
 
   const navigateToNote = useCallback(
     (noteId) => {
@@ -199,6 +136,71 @@ const MarkdownPreviewer = ({
       }
     },
     [activeStorageId, pushMessage, storageMap, getNotePathname, replace]
+  )
+
+  const rehypeReactConfig = useMemo(
+    () => ({
+      createElement: React.createElement,
+      Fragment: React.Fragment,
+      components: {
+        img: ({ src, ...props }: any) => {
+          if (src != null && !src.match('/')) {
+            const attachment = attachmentMap[src]
+            if (attachment != null) {
+              return <AttachmentImage attachment={attachment} {...props} />
+            }
+          }
+
+          return <ExpandableImage {...props} src={src} />
+        },
+        a: ({ href, children }: any) => {
+          return (
+            <a
+              className={'markdown__custom__note_link'}
+              href={href}
+              onClick={(event) => {
+                event.preventDefault()
+                if (href) {
+                  if (isNoteLinkId(href)) {
+                    navigateToNote(href)
+                  } else {
+                    openNew(href)
+                  }
+                }
+              }}
+            >
+              {children}
+            </a>
+          )
+        },
+        input: (props: React.HTMLProps<HTMLInputElement>) => {
+          const { type, checked } = props
+
+          if (type !== 'checkbox') {
+            return <input {...props} />
+          }
+
+          return (
+            <MarkdownCheckbox
+              index={checkboxIndexRef.current++}
+              checked={checked}
+              updateContent={updateContent}
+            />
+          )
+        },
+        pre: CodeFence,
+        flowchart: ({ children }: any) => {
+          return <Flowchart code={children[0]} />
+        },
+        chart: ({ children }: any) => {
+          return <Chart config={children[0]} />
+        },
+        'chart(yaml)': ({ children }: any) => {
+          return <Chart config={children[0]} isYml={true} />
+        },
+      },
+    }),
+    [attachmentMap, updateContent, navigateToNote]
   )
 
   const markdownProcessor = useMemo(() => {
@@ -258,7 +260,7 @@ const MarkdownPreviewer = ({
     previousContentRef.current = content
     previousThemeRef.current = codeBlockTheme
     renderContent()
-  }, [content, codeBlockTheme, rendering, renderContent, renderedContent])
+  }, [content, codeBlockTheme, renderContent])
 
   const StyledContainer = useMemo(() => {
     return styled.div`

--- a/src/components/organisms/ImportLegacyNotesForm.tsx
+++ b/src/components/organisms/ImportLegacyNotesForm.tsx
@@ -382,7 +382,7 @@ async function readdirOrEmpty(pathname: string) {
   try {
     return await readdir(pathname)
   } catch (error) {
-    if (error.code === 'ENOENT') {
+    if (error.message?.includes('ENOENT')) {
       return []
     }
     throw error

--- a/src/lib/db/FSNoteDb.ts
+++ b/src/lib/db/FSNoteDb.ts
@@ -780,7 +780,7 @@ class FSNoteDb implements NoteDb {
       const rawContent = await readFileAsString(jsonPathname)
       this.data = JSON.parse(rawContent)
     } catch (error) {
-      if (error.code === 'ENOENT') {
+      if (error.message?.includes('ENOENT')) {
         const defaultBoostNoteJSON: StorageJSONData = {
           folderMap: {},
           tagMap: {},

--- a/src/lib/electronOnly.ts
+++ b/src/lib/electronOnly.ts
@@ -141,7 +141,7 @@ async function prepareDirectory(pathname: string) {
       )
     }
   } catch (error) {
-    if (error.code === 'ENOENT') {
+    if (error.message?.includes('ENOENT')) {
       await mkdir(pathname)
     } else {
       throw error

--- a/src/shared/components/molecules/Form/index.tsx
+++ b/src/shared/components/molecules/Form/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import styled from '../../../lib/styled'
 import { LoadingButton } from '../../atoms/Button'
 import cc from 'classcat'
@@ -23,6 +23,13 @@ const Form: AppComponent<FormProps> = ({
   className,
 }) => {
   const [submitState, setSubmitState] = useState(false)
+  const mountedRef = useRef(true)
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
   return (
     <Container
       onSubmit={async (event: React.FormEvent) => {
@@ -31,15 +38,11 @@ const Form: AppComponent<FormProps> = ({
         }
 
         event.preventDefault()
-        if (onSubmit == null) {
-          return
-        }
         setSubmitState(true)
-        new Promise(async (resolve) => {
-          await onSubmit(event)
+        await onSubmit(event)
+        if (mountedRef.current) {
           setSubmitState(false)
-          resolve(true)
-        })
+        }
       }}
       className={cc(['form', className])}
     >


### PR DESCRIPTION
Fix IPC error.code loss and infinite render loop in MarkdownPreviewer

## Summary

- **IPC error.code not preserved across Electron IPC**: Electron does not
  preserve `error.code` when serializing exceptions through IPC, so catch
  blocks checking `error.code === 'ENOENT'` in `prepareDirectory`,
  `loadBoostNoteJSON`, and `readdirOrEmpty` always received `undefined` and
  re-threw instead of handling the error. Fixed by replacing the check with
  `error.message?.includes('ENOENT')` in `electronOnly.ts`, `FSNoteDb.ts`,
  and `ImportLegacyNotesForm.tsx`.

- **Infinite render loop in MarkdownPreviewer**: `remarkAdmonitionOptions`
  and `rehypeReactConfig` were plain object literals recreated on every
  render, which invalidated `markdownProcessor` and `renderContent` on every
  render and kept firing the main `useEffect` in a loop. Fixed by wrapping
  both in `useMemo`, moving `navigateToNote` above `rehypeReactConfig` as a
  stable dependency, and removing `renderedContent` and `rendering` from the
  `useEffect` dependency array.

- **State update on unmounted component in Form**: `setSubmitState(false)`
  was called inside a fire-and-forget Promise after `await onSubmit()`, which
  ran after the component unmounted when the submission closed its own modal.
  Fixed by awaiting `onSubmit` directly and guarding the state update behind
  a `mountedRef`.
 
 ## Verified

  - [x] Workspace that previously failed to load now initializes with defaults.
  - [x] Markdown preview renders once with no loop in the console.
  - [x] Creating a folder or workspace  no longer triggers the "state update on unmounted component" warning.

